### PR TITLE
Improve manifest-styled app url templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,21 +74,31 @@ spec:
 ```
 
 ### App Type Manifest
+Note: When using `kga create` use the `-t manifest` flag.
+
 ```yaml
 kind: kga-app
 version: v1alpha
-name: kubernetes-dashboard
+name: dashboard
 spec:
   manifest:
+    version: v2.0.0-rc6
+
+    # Use .Version to get spec.manifest.version
+    # Use .Template.<your key>
+    # Use .Config to access any field in config (see Go template rules) - hint: key names in this case begin
+    #     with capital letter.
+    #
+    # Example showing all three.
     urls:
-      - "https://raw.githubusercontent.com/kubernetes/dashboard/{{ .version }}/{{ .foo }}/deploy/recommended.yaml"
+    - "https://raw.githubusercontent.com/kubernetes/{{.Config.Name}}/{{ .Version }}/{{ .Template.foo }}/deploy/recommended.yaml"
     template:
-      version: v2.0.0-rc7
       foo: aio
 
   # Used just to demonstrate the usage of exclude spec
   exclude:
   - kind: Secret
+
 ```
 
 ## Why Did We Develop kga?

--- a/cmd/kga/cmd/generate.go
+++ b/cmd/kga/cmd/generate.go
@@ -62,7 +62,7 @@ otherwise we will use helm and hope it is in your path.`,
 
 		} else {
 			log.Info("Running URL manifest generation")
-			generate.DownloadManifestFiles(appPath, kgaConfig.Spec.Manifest)
+			generate.DownloadManifestFiles(appPath, kgaConfig.Spec.Manifest, kgaConfig)
 		}
 
 		if kgaConfig.HasExcludeSpec() {

--- a/pkg/config/kga_yaml.go
+++ b/pkg/config/kga_yaml.go
@@ -65,8 +65,7 @@ version: {{ .kgaVersion }}
 name: {{ .appName }}
 spec:
   manifest:
+    version: v2.0.0
     urls:
-    - "https://example.com/{{"{{"}} .version {{"}}"}}/manifests.yaml" # TODO - replace
-    template:
-      version: v2.0.0
+    - "https://example.com/{{"{{"}} .Version {{"}}"}}/manifests.yaml" # TODO - replace
 `

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -31,6 +31,7 @@ type HelmSpec struct {
 }
 
 type ManifestSpec struct {
+	Version string
 	Urls    []string
 	Template map[string]string
 }


### PR DESCRIPTION
Add additional field: `spec.manifest.version` which can be referenced directly in manifest url when templating as well as reference any field in the config using Go template rules. Example in README.md.

This PR is in reference to https://github.com/greenstatic/kga/pull/6#issuecomment-608793438